### PR TITLE
fix: bumblebee cannot be used on stable/nvidia-418.56

### DIFF
--- a/scripts/nvidia_intel/install_nvidia_intel_bumblebee.sh
+++ b/scripts/nvidia_intel/install_nvidia_intel_bumblebee.sh
@@ -12,4 +12,5 @@ apt-get -y --reinstall --allow-downgrades install \
     bumblebee-nvidia \
     primus \
     nvidia-driver \
+    xserver-xorg-video-nvidia \
     nvidia-driver-libs-nonglvnd

--- a/scripts/nvidia_intel/prepare_nvidia_intel_bumblebee.sh
+++ b/scripts/nvidia_intel/prepare_nvidia_intel_bumblebee.sh
@@ -7,6 +7,7 @@ COMMANDS=(
     "apt-get update"
     "apt-get install -d --reinstall -y --allow-downgrades \
         nvidia-driver \
+        xserver-xorg-video-nvidia \
         nvidia-driver-libs-nonglvnd"
     "cd /var/cache/apt/archives"
     "apt-get download \


### PR DESCRIPTION
单独装 nvidia-driver 和  xx-libs-nonglvnd 会有依赖问题，但是同时装 xserver-xorg-video-nvidia 就没有问题。